### PR TITLE
Add ability to ignore nodes from the circular saw before adding them, and remove nodes from the circular saw after adding them

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -20,6 +20,7 @@ circular_saw.known_stairs = setmetatable({}, {
 
 -- This is populated by stairsplus:register_all:
 circular_saw.known_nodes = {}
+circular_saw.ignored_nodes = {}
 
 -- How many microblocks does this shape at the output inventory cost:
 -- It may cause slight loss, but no gain.
@@ -279,7 +280,7 @@ function circular_saw.allow_metadata_inventory_put(
 			end
 		end
 		for name, t in pairs(circular_saw.known_nodes) do
-			if name == stackname and inv:room_for_item("input", stack) then
+			if t and name == stackname and inv:room_for_item("input", stack) then
 				return count
 			end
 		end

--- a/stairsplus/common.lua
+++ b/stairsplus/common.lua
@@ -131,9 +131,9 @@ end
 local ignored_nodes = {}
 stairsplus.remove_and_ignore = function(category, alternate, modname, subname, recipeitem)
 	local name = modname.. ":" .. category .. "_" .. subname .. alternate
+	ignored_nodes[name] = true
 	if minetest.registered_nodes[name] then
 		minetest.registered_nodes[name] = nil
-		ignored_nodes[name] = true
 		minetest.unregister_item(name)
 	end
 end

--- a/stairsplus/common.lua
+++ b/stairsplus/common.lua
@@ -118,7 +118,29 @@ stairsplus.rotate_node_aux = function(itemstack, placer, pointed_thing)
 	return minetest.item_place(itemstack, placer, pointed_thing, p2)
 end
 
+stairsplus.remove_all_and_ignore = function(modname, subname, recipeitem)
+	circular_saw.ignored_nodes[recipeitem] = {modname,subname}
+	circular_saw.known_nodes[recipeitem] = nil
+	for category, alternates in pairs(stairsplus.defs) do
+		for alternate, def in pairs(alternates) do
+			stairsplus.remove_and_ignore(category, alternate, modname, subname, recipeitem)
+		end
+	end
+end
+
+local ignored_nodes = {}
+stairsplus.remove_and_ignore = function(category, alternate, modname, subname, recipeitem)
+	local name = modname.. ":" .. category .. "_" .. subname .. alternate
+	if minetest.registered_nodes[name] then
+		minetest.registered_nodes[name] = nil
+		ignored_nodes[name] = true
+		minetest.unregister_item(name)
+	end
+end
+
 stairsplus.register_single = function(category, alternate, info, modname, subname, recipeitem, fields)
+	local name = modname.. ":" .. category .. "_" .. subname .. alternate
+	if ignored_nodes[name] then return end
 	local src_def = minetest.registered_nodes[recipeitem] or {}
 	local desc_base = descriptions[category]:format(fields.description)
 	local def = {}
@@ -175,6 +197,6 @@ stairsplus.register_single = function(category, alternate, info, modname, subnam
 		def.drop = modname.. ":" .. category .. "_" .. fields.drop .. alternate
 	end
 
-	minetest.register_node(":" ..modname.. ":" .. category .. "_" .. subname .. alternate, def)
+	minetest.register_node(":" .. name, def)
 	stairsplus.register_recipes(category, alternate, modname, subname, recipeitem)
 end

--- a/stairsplus/common.lua
+++ b/stairsplus/common.lua
@@ -133,7 +133,6 @@ stairsplus.remove_and_ignore = function(category, alternate, modname, subname, r
 	local name = modname.. ":" .. category .. "_" .. subname .. alternate
 	ignored_nodes[name] = true
 	if minetest.registered_nodes[name] then
-		minetest.registered_nodes[name] = nil
 		minetest.unregister_item(name)
 	end
 end

--- a/stairsplus/custom.lua
+++ b/stairsplus/custom.lua
@@ -88,6 +88,8 @@ function stairsplus:register_custom_subset_alias_force(subset, modname_old, subn
 end
 
 function stairsplus:register_custom_subset(subset, modname, subname, recipeitem, fields)
+	if circular_saw.ignored_nodes[recipeitem] then return end
+
 	local subset_copy = table.copy(subset)
 	for k, v in pairs(subset_copy) do
 		stairsplus.register_single(v[1], v[2], stairsplus.defs[v[1]][v[2]], modname, subname, recipeitem, fields)

--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -34,6 +34,8 @@ function stairsplus:register_micro_alias_force(modname_old, subname_old, modname
 end
 
 function stairsplus:register_micro(modname, subname, recipeitem, fields)
+	if circular_saw.ignored_nodes[recipeitem] then return end
+
 	local defs = table.copy(stairsplus.defs["micro"])
 	for alternate, def in pairs(defs) do
 		stairsplus.register_single("micro", alternate, def, modname, subname, recipeitem, fields)

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -34,6 +34,8 @@ function stairsplus:register_panel_alias_force(modname_old, subname_old, modname
 end
 
 function stairsplus:register_panel(modname, subname, recipeitem, fields)
+	if circular_saw.ignored_nodes[recipeitem] then return end
+
 	local defs = table.copy(stairsplus.defs["panel"])
 	for alternate, def in pairs(defs) do
 		stairsplus.register_single("panel", alternate, def, modname, subname, recipeitem, fields)

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -34,6 +34,8 @@ function stairsplus:register_slab_alias_force(modname_old, subname_old, modname_
 end
 
 function stairsplus:register_slab(modname, subname, recipeitem, fields)
+	if circular_saw.ignored_nodes[recipeitem] then return end
+
 	local defs = table.copy(stairsplus.defs["slab"])
 	for alternate, shape in pairs(defs) do
 		stairsplus.register_single("slab", alternate, shape, modname, subname, recipeitem, fields)

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -34,6 +34,8 @@ function stairsplus:register_slope_alias_force(modname_old, subname_old, modname
 end
 
 function stairsplus:register_slope(modname, subname, recipeitem, fields)
+	if circular_saw.ignored_nodes[recipeitem] then return end
+
 	local defs = table.copy(stairsplus.defs["slope"])
 	for alternate, def in pairs(defs) do
 		stairsplus.register_single("slope", alternate, def, modname, subname, recipeitem, fields)

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -34,6 +34,8 @@ function stairsplus:register_stair_alias_force(modname_old, subname_old, modname
 end
 
 function stairsplus:register_stair(modname, subname, recipeitem, fields)
+	if circular_saw.ignored_nodes[recipeitem] then return end
+
 	local defs = table.copy(stairsplus.defs["stair"])
 	for alternate, def in pairs(defs) do
 		stairsplus.register_single("stair", alternate, def, modname, subname, recipeitem, fields)


### PR DESCRIPTION
Record list of ignored nodes to avoid adding them if they eventually get registered
Removes node variations if a node has already been registered


Helps solve https://github.com/BlockySurvival/issue-tracker/issues/292