### PR TITLE
Do not copy the 'marble' group into microblocks

### DIFF
--- a/stairsplus/init.lua
+++ b/stairsplus/init.lua
@@ -21,11 +21,19 @@ then
 	stairsplus.expect_infinite_stacks = true
 end
 
+local do_not_copy_groups = {
+	wood = true,
+	stone = true,
+	wool = true,
+	tree = true,
+	marble = true
+}
+
 function stairsplus:prepare_groups(groups)
 	local result = {}
 	if groups then
 		for k, v in pairs(groups) do
-			if k ~= "wood" and k ~= "stone" and k ~= "wool" and k ~= "tree" then
+			if not do_not_copy_groups[k] then
 				result[k] = v
 			end
 		end


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/238

I would have liked to make this configurable but this should load before any mod that might be able to configure it
We could do this via settings, but I'm not sure there's a good way to do a list there, I might write something more generic for that and come back to this